### PR TITLE
fix: libraw has changed its api

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libkf5kdcraw (21.08.0-1deepin1) unstable; urgency=medium
+
+  * fix: libraw has changed its api so compilation of this package is
+    prevented
+
+ -- sisungo <sisungo@icloud.com>  Sun, 21 Sep 2025 15:54:08 +0800
+
 libkf5kdcraw (21.08.0-1) unstable; urgency=medium
 
   [ Norbert Preining ]

--- a/debian/patches/fix-libraw-api-change.diff
+++ b/debian/patches/fix-libraw-api-change.diff
@@ -1,0 +1,12 @@
+--- libkf5kdcraw-21.08.0.orig/src/kdcraw.cpp
++++ libkf5kdcraw-21.08.0/src/kdcraw.cpp
+@@ -357,8 +357,8 @@ bool KDcraw::extractRAWData(const QStrin
+     d->setProgress(0.3);
+ 
+     raw.imgdata.params.output_bps  = 16;
+-    raw.imgdata.params.shot_select = shotSelect;
++    raw.imgdata.rawparams.shot_select = shotSelect;
+     ret                            = raw.unpack();
+ 
+     if (ret != LIBRAW_SUCCESS)
+     {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+fix-libraw-api-change.diff


### PR DESCRIPTION
libraw has changed its api, and compilation of this package is prevented. This PR adds a patch to adapt the code to the new API.